### PR TITLE
Match referring directory to its repository name.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ruboty-zulip.gemspec
 gemspec
 
-gem "zulip-client", path: "../zulip-client"
+gem "zulip-client", path: "../ruby-zulip-client"


### PR DESCRIPTION
zulip-client's repository is https://github.com/okkez/ruby-zulip-client so the directory will be named `ruby-zulip-client` by default.

開発に初めて関わる人に対する無駄な填りポイントになるため、参照先ディレクトリ名は既定の物に合わせておく方がよいと思うのですが、どうでしょうか？